### PR TITLE
Update Boxes.__eq__ in response to NumPy 1.14.3 DeprecationWarning

### DIFF
--- a/netharn/models/yolo2/light_yolo.py
+++ b/netharn/models/yolo2/light_yolo.py
@@ -65,7 +65,7 @@ class Reorg(nn.Module):
         self.darknet = True
 
     def __repr__(self):
-        return f'{self.__class__.__name__} (stride={self.stride}, darknet_compatible_mode={self.darknet})'
+        return '{self.__class__.__name__} (stride={self.stride}, darknet_compatible_mode={self.darknet})'
 
     def forward(self, x):
         assert(x.data.dim() == 4)

--- a/netharn/util/util_boxes.py
+++ b/netharn/util/util_boxes.py
@@ -526,6 +526,19 @@ class Boxes(ub.NiceRepr, _BoxConversionMixins, _BoxPropertyMixins, _BoxTransform
         return subset
 
     def __eq__(self, other):
+        """
+        Tests equality of two Boxes objects
+        
+        Example:
+            >>> box0 = box1 = Boxes([[1, 2, 3, 4]], 'xywh')
+            >>> box2 = Boxes(box0.data, 'tlbr')
+            >>> box3 = Boxes([[0, 2, 3, 4]], box0.format)
+            >>> box4 = Boxes(box0.data, box2.format)
+            >>> assert box0 == box1
+            >>> assert not box0 == box2
+            >>> assert not box2 == box3
+            >>> assert box2 == box4
+        """
         return np.array_equal(self.data, other.data) and self.format == other.format
 
     def __nice__(self):
@@ -602,7 +615,7 @@ class Boxes(ub.NiceRepr, _BoxConversionMixins, _BoxPropertyMixins, _BoxTransform
         """ converts tensors to numpy """
         new_self = self.copy()
         if torch.is_tensor(self.data):
-            new_self.data = new_self.data.to('cpu').numpy()
+            new_self.data = new_self.data.cpu().numpy()
         return new_self
 
     def ious(self, other, bias=0, mode=None):

--- a/netharn/util/util_boxes.py
+++ b/netharn/util/util_boxes.py
@@ -526,7 +526,7 @@ class Boxes(ub.NiceRepr, _BoxConversionMixins, _BoxPropertyMixins, _BoxTransform
         return subset
 
     def __eq__(self, other):
-        return np.all(self.data == other.data) and self.format == other.format
+        return np.array_equal(self.data, other.data) and self.format == other.format
 
     def __nice__(self):
         # return self.format + ', shape=' + str(list(self.data.shape))
@@ -602,7 +602,7 @@ class Boxes(ub.NiceRepr, _BoxConversionMixins, _BoxPropertyMixins, _BoxTransform
         """ converts tensors to numpy """
         new_self = self.copy()
         if torch.is_tensor(self.data):
-            new_self.data = new_self.data.cpu().numpy()
+            new_self.data = new_self.data.to('cpu').numpy()
         return new_self
 
     def ious(self, other, bias=0, mode=None):


### PR DESCRIPTION
When comparing differently-shaped arrays, Numpy 1.14.3 throws:
```DeprecationWarning: elementwise == comparison failed; this will raise an error in the future.```

Change equality test to `np.array_equal()` for robust equality checking.